### PR TITLE
[EQP-26][EQP-27] 組織関連のDBスキーマを追加

### DIFF
--- a/docs/er.pu
+++ b/docs/er.pu
@@ -82,12 +82,52 @@ entity organization_user as "組織所属リスト" {
   delete_user_id: uuidv7 <<NULLABLE>>
 }
 
+entity organization_equipment as "組織物品リスト" {
+  id: uuidv7 <<PK>>
+  --
+  organization_id: uuidv7 <<FK>>
+  equipment_id: uuidv7 <<FK>>
+  created_at: datetime 
+  updated_at: datetime
+  deleted_at: datetime <<NULLABLE>>
+  create_user_id: uuidv7
+  update_user_id: uuidv7
+  delete_user_id: uuidv7 <<NULLABLE>>
+}
+
+entity roles as "ロールマスタ" {
+  id: uuidv7 <<PK>>
+  --
+  name: string
+  created_at: datetime 
+  updated_at: datetime
+  deleted_at: datetime <<NULLABLE>>
+}
+
+entity user_roles as "ユーザーロール" {
+  id: uuidv7 <<PK>>
+  --
+  user_id: uuidv7 <<FK>>
+  organization_id: uuidv7 <<FK>> <<NULLABLE>>
+  role_id: uuidv7 <<FK>>
+  created_at: datetime 
+  updated_at: datetime
+  deleted_at: datetime <<NULLABLE>>
+  create_user_id: uuidv7
+  update_user_id: uuidv7
+  delete_user_id: uuidv7 <<NULLABLE>>
+}
 
 user ||--|| user_login
 user ||--o{ equipment_user
 equipment ||--o{ equipment_user
 organization ||--o{ organization_user
-organization_user }--|| user
+organization_user }o--|| user
+organization ||--o{ organization_equipment
+organization_equipment }--|| equipment
+organization ||--{ user_roles
+user ||--o{ user_roles
+roles ||--o{ user_roles
 
 /'
     ### cardinality ###

--- a/docs/er.pu
+++ b/docs/er.pu
@@ -43,6 +43,17 @@ entity equipment as "物品マスタ" {
   delete_user_id: uuidv7 <<NULLABLE>>
 }
 
+entity organization as "組織マスタ" {
+  id: uuidv7 <<PK>>
+  --
+  name: string
+  created_at: datetime 
+  updated_at: datetime
+  deleted_at: datetime <<NULLABLE>>
+  create_user_id: uuidv7
+  update_user_id: uuidv7
+  delete_user_id: uuidv7 <<NULLABLE>>
+}
 
 entity equipment_user as "物品貸出履歴" {
   id: uuidv7 <<PK>>
@@ -58,9 +69,25 @@ entity equipment_user as "物品貸出履歴" {
   delete_user_id: uuidv7 <<NULLABLE>> /' 返却したユーザー '/
 }
 
+entity organization_user as "組織所属リスト" {
+  id: uuidv7 <<PK>>
+  --
+  organization_id: uuidv7 <<FK>>
+  user_id: uuidv7 <<FK>>
+  created_at: datetime 
+  updated_at: datetime
+  deleted_at: datetime <<NULLABLE>>
+  create_user_id: uuidv7
+  update_user_id: uuidv7
+  delete_user_id: uuidv7 <<NULLABLE>>
+}
+
+
 user ||--|| user_login
 user ||--o{ equipment_user
 equipment ||--o{ equipment_user
+organization ||--o{ organization_user
+organization_user }--|| user
 
 /'
     ### cardinality ###

--- a/docs/er.pu
+++ b/docs/er.pu
@@ -102,6 +102,9 @@ entity roles as "ロールマスタ" {
   created_at: datetime 
   updated_at: datetime
   deleted_at: datetime <<NULLABLE>>
+  create_user_id: uuidv7
+  update_user_id: uuidv7
+  delete_user_id: uuidv7 <<NULLABLE>>
 }
 
 entity user_roles as "ユーザーロール" {


### PR DESCRIPTION
組織関連の機能の実装にあたり，以下の通りDBスキーマを拡張しました．
- 組織関連
  - 組織マスタの追加
  - 組織とユーザー，物品の関連付けを定義するスキーマの追加
- ロール関連
  - ロールマスタの追加
  - ロールとユーザーの関連付けを定義するスキーマの追加